### PR TITLE
fix: add client url env var on cors

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,7 +24,7 @@ app.register(fastifyCors, {
     const allowedOrigins = [
       'http://localhost:5173',
       'http://localhost:3333',
-      'https://meu-site.com',
+      process.env.CLIENT_URL,
     ]
     if (!origin || allowedOrigins.includes(origin)) {
       cb(null, true)


### PR DESCRIPTION
- Fix Allowed CORS Origins adding `CLIENT_URL` env var